### PR TITLE
Naming column 1 of datasources_headers.txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,6 +328,15 @@ This property has
 <section id="_data_properties">
 <h2>Data Properties</h2>
 
+<div id="conventionalName" about="http://vocabularies.bridgedb.org/ops#conventionalName" typeof="owl:DatatypeProperty">
+<h3 property="rdfs:label">Conventional Name</h3>
+<code property="skos:prefLabel">bdb:conventionalName</code>
+<p><span property="dc:description">The conventional name of the data source, as per established usage norms for the BridgeDb project.</span>
+This property has
+  <a property="rdfs:domain" href="http://vocabularies.bridgedb.org/ops#DataSource">DataSource</a>
+  as domain.</p>
+</div>
+
 <div id="fullName" about="http://vocabularies.bridgedb.org/ops#fullName" typeof="owl:DatatypeProperty">
 <h3 property="rdfs:label">Full Name</h3>
 <code property="skos:prefLabel">bdb:fullName</code>


### PR DESCRIPTION
Column 1 of [datasources_headers.txt](https://github.com/bridgedb/BridgeDb/blob/bridgedb2.x/org.bridgedb.bio/resources/org/bridgedb/bio/datasources_headers.txt) does not have a term in this vocabulary. I used `conventionalName` as per the column header from datasources_headers.txt, but alternate terms could be `shortName` or `bridgeDbName`. If anyone has a strong preference, just let me know so I can update this.
